### PR TITLE
[Feature-0424](#35) - schedule - 부서별 일정 상세 조회 테스트

### DIFF
--- a/src/main/java/com/devsplan/ketchup/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/devsplan/ketchup/schedule/repository/ScheduleRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByDepartment(Department department);
+
+    List<Schedule> findByDepartmentAndSkdNo(Department department, int skdNo);
 }

--- a/src/main/java/com/devsplan/ketchup/schedule/service/ScheduleService.java
+++ b/src/main/java/com/devsplan/ketchup/schedule/service/ScheduleService.java
@@ -47,6 +47,25 @@ public class ScheduleService {
                 }).collect(Collectors.toList());
     }
 
+    public List<ScheduleDTO> selectScheduleDetail(int dptNo, int skdNo) {
+        Department department = departmentRepository.findById(dptNo)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 부서를 찾을 수 없습니다: " + dptNo));
+
+        List<Schedule> scheduleDetail = scheduleRepository.findByDepartmentAndSkdNo(department, skdNo);
+        return scheduleDetail.stream()
+                .map(schedule -> {
+                    ScheduleDTO scheduleDTO = new ScheduleDTO();
+                    scheduleDTO.setSkdNo(schedule.getSkdNo());
+                    scheduleDTO.setDptNo(new DepartmentDTO(schedule.getDepartment().getDptNo()));
+                    scheduleDTO.setSkdName(schedule.getSkdName());
+                    scheduleDTO.setSkdStartDttm(schedule.getSkdStartDttm());
+                    scheduleDTO.setSkdEndDttm(schedule.getSkdEndDttm());
+                    scheduleDTO.setSkdLocation(schedule.getSkdLocation());
+                    scheduleDTO.setSkdMemo(schedule.getSkdMemo());
+                    return scheduleDTO;
+                }).collect(Collectors.toList());
+    }
+
     @Transactional
     public void insertSchedule(ScheduleDTO newSchedule) {
 
@@ -73,5 +92,6 @@ public class ScheduleService {
 
         scheduleRepository.save(schedule);
     }
+
 
 }

--- a/src/test/java/com/devsplan/ketchup/schedule/ScheduleRestTests.java
+++ b/src/test/java/com/devsplan/ketchup/schedule/ScheduleRestTests.java
@@ -25,8 +25,6 @@ public class ScheduleRestTests {
     @DisplayName("부서별 일정 목록 조회")
     @Test
     void selectScheduleList() {
-        // /department/{departmentno}
-
         // given
         int dptNo = 1;
 
@@ -35,24 +33,28 @@ public class ScheduleRestTests {
 
         // then
         Assertions.assertNotNull(foundSchedule);
-        System.out.println("조회한 일정 = " + foundSchedule);
+        System.out.println("부서별 일정 목록 조회 = " + foundSchedule);
+
     }
 
     @DisplayName("부서별 일정 상세 조회")
     @Test
     void selectScheduleDetail() {
-        // /department/{departmentno}/schedules/{scheduleno}
-
         // given
+        int dptNo = 1;
+        int skdNo = 2;
 
         // when
+        List<ScheduleDTO> foundSchedule = scheduleService.selectScheduleDetail(dptNo, skdNo);
 
         // then
+        Assertions.assertNotNull(foundSchedule);
+        System.out.println("부서별 일정 상세 조회 = " + foundSchedule);
     }
 
     private static Stream<Arguments> getScheduleInfo() {
         return Stream.of(
-                Arguments.of(5, 1, "새로 등록한 일정 번호는 6", LocalDateTime.of(2024, 6, 23, 10, 0), LocalDateTime.of(2024, 6, 23, 23, 0), "새로운 위치", "새로 등록한 일정이 정상적으로 반영되었습니다22222")
+                Arguments.of(3, 1, "신규 등록한 일정1", LocalDateTime.of(2024, 6, 23, 10, 0), LocalDateTime.of(2024, 6, 23, 23, 0), "신규 위치", "신규 등록 일정이 정상적으로 반영되었습니다.")
         );
     }
 
@@ -60,8 +62,6 @@ public class ScheduleRestTests {
     @ParameterizedTest
     @MethodSource("getScheduleInfo")
     void insertSchedule(int skdNo, int dptNo, String skdName, LocalDateTime skdStartDttm, LocalDateTime skdEndDttm, String skdLocation, String skdMemo) {
-        // /schedules
-
         // given
         ScheduleDTO newSchedule = new ScheduleDTO(
                 skdNo,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Jay-20240424-v2

### 변경 사항
1. 일정 상세 조회 테스트 코드 작성: 부서 번호와 일정 번호를 매개변수로 테스트
2. 일정 서비스 로직 작성: 전달받은 매개변수를 findByDepartmentAndSkdNo() 메소드에 담아 일정 레포지토리로 전달
3. 일정 레포지토리에 메소드 작성: 레포지토리에서 DB를 조회하여 반환

### 테스트 결과
부서별 일정 상세 조회 테스트 성공했습니다.

#이슈번호
#35 