### PR TITLE
[Feature-0425](#31 #32) - 메일 - 메일 수신자 등록, 발신 메일, 수신 메일 조회 테스트

### DIFF
--- a/src/main/java/com/devsplan/ketchup/mail/dto/MailDTO.java
+++ b/src/main/java/com/devsplan/ketchup/mail/dto/MailDTO.java
@@ -9,7 +9,7 @@ import java.util.List;
 @ToString
 public class MailDTO {
     private int mailNo;                     // 메일 번호
-    private String sender;                  // 발신자(사원 번호)
+    private int senderMem;               // 발신자 사원 번호
     private String mailTitle;               // 메일 제목
     private String mailContent;             // 메일 내용
     private char sendCancelStatus;          // 메일 발송 취소 여부
@@ -19,22 +19,12 @@ public class MailDTO {
     public MailDTO() {
     }
 
-    public MailDTO(int mailNo, String sender, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus) {
+    public MailDTO(int mailNo, int senderMem, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus) {
         this.mailNo = mailNo;
-        this.sender = sender;
+        this.senderMem = senderMem;
         this.mailTitle = mailTitle;
         this.mailContent = mailContent;
         this.sendCancelStatus = sendCancelStatus;
         this.sendDelStatus = sendDelStatus;
-    }
-
-    public MailDTO(int mailNo, String sender, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus, List<ReceiverDTO> receivers) {
-        this.mailNo = mailNo;
-        this.sender = sender;
-        this.mailTitle = mailTitle;
-        this.mailContent = mailContent;
-        this.sendCancelStatus = sendCancelStatus;
-        this.sendDelStatus = sendDelStatus;
-        this.receivers = receivers;
     }
 }

--- a/src/main/java/com/devsplan/ketchup/mail/dto/ReceiverDTO.java
+++ b/src/main/java/com/devsplan/ketchup/mail/dto/ReceiverDTO.java
@@ -10,17 +10,21 @@ import java.sql.Timestamp;
 public class ReceiverDTO {
     private int receiverNo;             // 수신자 번호
     private int mailNo;                 // 메일 번호
-    private String receiverName;        // 수신자 이름
+    private int receiverMem;            // 수신자 사원 번호
     private Timestamp readTime;         // 메일 읽은 시간
     private char receiverDelStatus;     // 수신 메일 삭제 여부
 
     public ReceiverDTO() {
     }
 
-    public ReceiverDTO(int receiverNo, int mailNo, String receiverName, Timestamp readTime, char receiverDelStatus) {
+    public ReceiverDTO(int mailNo) {
+        this.mailNo = mailNo;
+    }
+
+    public ReceiverDTO(int receiverNo, int mailNo, int receiverMem, Timestamp readTime, char receiverDelStatus) {
         this.receiverNo = receiverNo;
         this.mailNo = mailNo;
-        this.receiverName = receiverName;
+        this.receiverMem = receiverMem;
         this.readTime = readTime;
         this.receiverDelStatus = receiverDelStatus;
     }

--- a/src/main/java/com/devsplan/ketchup/mail/entity/Mail.java
+++ b/src/main/java/com/devsplan/ketchup/mail/entity/Mail.java
@@ -17,8 +17,8 @@ public class Mail {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int mailNo;
 
-    @Column(name = "SENDER", length = 50, nullable = false)
-    private String sender;
+    @Column(name = "SENDER_MEM", length = 50, nullable = false)
+    private int senderMem;
 
     @Column(name = "MAIL_TITLE", length = 200, nullable = false)
     private String mailTitle;
@@ -35,15 +35,15 @@ public class Mail {
 //    @OneToMany(mappedBy = "mailNo")
 //    private List<MailFile> mailFiles;
 
-//    @Setter
-//    @OneToMany(mappedBy = "mailNo", cascade = CascadeType.PERSIST)
-//    private List<Receiver> Receivers;
+    @Setter
+    @OneToMany(mappedBy = "mailNo", cascade = CascadeType.PERSIST)
+    private List<Receiver> Receivers;
 
     protected Mail() {}
 
-    public Mail(int mailNo, String sender, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus) {
+    public Mail(int mailNo, int senderMem, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus) {
         this.mailNo = mailNo;
-        this.sender = sender;
+        this.senderMem = senderMem;
         this.mailTitle = mailTitle;
         this.mailContent = mailContent;
         this.sendCancelStatus = sendCancelStatus;

--- a/src/main/java/com/devsplan/ketchup/mail/entity/MailFile.java
+++ b/src/main/java/com/devsplan/ketchup/mail/entity/MailFile.java
@@ -1,9 +1,13 @@
 package com.devsplan.ketchup.mail.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "tbl_mail_file")
+@Getter
+@ToString
 public class MailFile {
     @Id
     @Column(name = "MAIL_FILE_NO", nullable = false)

--- a/src/main/java/com/devsplan/ketchup/mail/entity/Receiver.java
+++ b/src/main/java/com/devsplan/ketchup/mail/entity/Receiver.java
@@ -1,11 +1,15 @@
 package com.devsplan.ketchup.mail.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.ToString;
 
 import java.sql.Timestamp;
 
 @Entity
 @Table(name = "tbl_receiver")
+@Getter
+@ToString
 public class Receiver {
     @Id
     @Column(name = "RECEIVER_NO", nullable = false)
@@ -17,8 +21,8 @@ public class Receiver {
     @Column(name = "MAIL_NO")
     private int mailNo;
 
-    @Column(name = "RECEIVER_NAME", nullable = false)
-    private String receiverName;
+    @Column(name = "RECEIVER_MEM", nullable = false)
+    private int receiverMem;
 
     @Column(name = "READ_TIME")
     private Timestamp readTime;
@@ -28,10 +32,10 @@ public class Receiver {
 
     protected Receiver() {}
 
-    public Receiver(int receiverNo, int mailNo, String receiverName, Timestamp readTime, char receiverDelStatus) {
+    public Receiver(int receiverNo, int mailNo, int receiverMem, Timestamp readTime, char receiverDelStatus) {
         this.receiverNo = receiverNo;
         this.mailNo = mailNo;
-        this.receiverName = receiverName;
+        this.receiverMem = receiverMem;
         this.readTime = readTime;
         this.receiverDelStatus = receiverDelStatus;
     }

--- a/src/main/java/com/devsplan/ketchup/mail/repository/MailRepository.java
+++ b/src/main/java/com/devsplan/ketchup/mail/repository/MailRepository.java
@@ -1,9 +1,6 @@
 package com.devsplan.ketchup.mail.repository;
 
-import com.devsplan.ketchup.mail.dto.MailDTO;
 import com.devsplan.ketchup.mail.entity.Mail;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +8,6 @@ import java.util.List;
 
 @Repository
 public interface MailRepository extends JpaRepository<Mail, Integer> {
-    List<Mail> findBySender(String senderNo);
+    List<Mail> findBySenderMem(int senderMem);
+    Mail findByMailNo(int i);
 }

--- a/src/main/java/com/devsplan/ketchup/mail/repository/ReceiverRepository.java
+++ b/src/main/java/com/devsplan/ketchup/mail/repository/ReceiverRepository.java
@@ -1,0 +1,13 @@
+package com.devsplan.ketchup.mail.repository;
+
+import com.devsplan.ketchup.mail.dto.ReceiverDTO;
+import com.devsplan.ketchup.mail.entity.Receiver;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReceiverRepository  extends JpaRepository<Receiver, Integer> {
+    List<Receiver> findByReceiverMem(int receiverTest);
+}

--- a/src/main/java/com/devsplan/ketchup/mail/service/MailService.java
+++ b/src/main/java/com/devsplan/ketchup/mail/service/MailService.java
@@ -1,13 +1,14 @@
 package com.devsplan.ketchup.mail.service;
 
 import com.devsplan.ketchup.mail.dto.MailDTO;
+import com.devsplan.ketchup.mail.dto.ReceiverDTO;
 import com.devsplan.ketchup.mail.entity.Mail;
 import com.devsplan.ketchup.mail.entity.Receiver;
 import com.devsplan.ketchup.mail.repository.MailRepository;
+import com.devsplan.ketchup.mail.repository.ReceiverRepository;
 import jakarta.transaction.Transactional;
-import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,40 +17,89 @@ import java.util.stream.Collectors;
 @Service
 public class MailService {
     private final MailRepository mailRepository;
+    private final ReceiverRepository receiverRepository;
 
-    public MailService(MailRepository mailRepository) {
+    public MailService(MailRepository mailRepository, ReceiverRepository receiverRepository) {
         this.mailRepository = mailRepository;
+        this.receiverRepository = receiverRepository;
     }
 
     @Transactional
-    public void insertMail(MailDTO mailInfo) {
+    public void insertMail(MailDTO mailInfo, ReceiverDTO receiverInfo) {
         Mail mail = new Mail(
                 mailInfo.getMailNo(),
-                mailInfo.getSender(),
+                mailInfo.getSenderMem(),
                 mailInfo.getMailTitle(),
                 mailInfo.getMailContent(),
                 mailInfo.getSendCancelStatus(),
                 mailInfo.getSendDelStatus()
         );
 
-//        Receiver recevier = new Receiver(
-//                mailInfo.getReceivers().get(0).getReceiverNo(),
-//                mailInfo.getMailNo(),
-//                mailInfo.getReceivers().get(0).getReceiverName(),
-//                mailInfo.getReceivers().get(0).getReadTime(),
-//                mailInfo.getReceivers().get(0).getReceiverDelStatus()
-//        );
-//
-//        List<Receiver> receiverList = new ArrayList<>();
-//        receiverList.add(recevier);
-//        mail.setReceivers(receiverList);
-
         mailRepository.save(mail);
+
+        Receiver receiver = new Receiver(
+                receiverInfo.getReceiverNo(),
+                receiverInfo.getMailNo(),
+                receiverInfo.getReceiverMem(),
+                receiverInfo.getReadTime(),
+                receiverInfo.getReceiverDelStatus()
+        );
+
+        receiverRepository.save(receiver);
     }
 
+//    @Transactional
+//    public void insertReceiver(ReceiverDTO receiverInfo) {
+//
+//    }
+
     @Transactional
-    public List<Mail> selectMailList(String senderNo) {
-        List<Mail> mailList = mailRepository.findBySender(senderNo);
+    public List<MailDTO> selectSendMailList(int senderMem) {
+        List<Mail> mailList = mailRepository.findBySenderMem(senderMem);
+
+        return mailList.stream()
+                .map(mail -> new MailDTO(
+                        mail.getMailNo()
+                        , mail.getSenderMem()
+                        , mail.getMailTitle()
+                        , mail.getMailContent()
+                        , mail.getSendCancelStatus()
+                        , mail.getSendDelStatus()
+                ))
+                .toList();
+    }
+
+    public List<MailDTO> selectReceiveMailList(int receiverTest) {
+        List<Receiver> receiveList = receiverRepository.findByReceiverMem(receiverTest);
+
+        List<ReceiverDTO> result =
+                receiveList.stream()
+                .map(receiver -> new ReceiverDTO(
+                        receiver.getReceiverNo(),
+                        receiver.getMailNo(),
+                        receiver.getReceiverMem(),
+                        receiver.getReadTime(),
+                        receiver.getReceiverDelStatus()
+                ))
+                .toList();
+
+        List<MailDTO> mailList = new ArrayList<>();
+
+        for(int i = 0; i < result.size(); i++) {
+            System.out.println("음하하하하하하하하하");
+            int mailNo = result.get(i).getMailNo();
+            Mail receiveMail = mailRepository.findByMailNo(mailNo);
+            MailDTO mail = new MailDTO(
+                    receiveMail.getMailNo(),
+                    receiveMail.getSenderMem(),
+                    receiveMail.getMailTitle(),
+                    receiveMail.getMailContent(),
+                    receiveMail.getSendCancelStatus(),
+                    receiveMail.getSendDelStatus()
+            );
+
+            mailList.add(mail);
+        }
 
         return mailList;
     }

--- a/src/test/java/com/devsplan/ketchup/mail/MailRestTests.java
+++ b/src/test/java/com/devsplan/ketchup/mail/MailRestTests.java
@@ -8,6 +8,7 @@ import com.devsplan.ketchup.mail.entity.MailFile;
 import com.devsplan.ketchup.mail.service.MailService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,11 +29,15 @@ public class MailRestTests {
     private static Stream<Arguments> getMail() {
         return Stream.of(
                 Arguments.of(
-                        1,
-                        "240423-001",
-                        "[자료 요청] 1분기 실적보고서 내 영업실 데이터",
-                        "지난번 공유주신 1분기 실적보고서는 잘 받았습니다. 리포터에 산입하신 영업팀의 지난분기 계약 및 실적 데이터 전달을 부탁드리겠습니다.",
+                        3,
+                        240425003,
+                        "3[자료 요청] 1분기 실적보고서 내 영업실 데이터",
+                        "3지난번 공유주신 1분기 실적보고서는 잘 받았습니다. 리포터에 산입하신 영업팀의 지난분기 계약 및 실적 데이터 전달을 부탁드리겠습니다.",
                         'N',
+                        'N',
+                        3,
+                        240425001,
+                        null,
                         'N'
                 )
         );
@@ -41,56 +46,63 @@ public class MailRestTests {
     @DisplayName("메일 전송")
     @ParameterizedTest
     @MethodSource("getMail")
-    void insertMail(int mailNo, String sender, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus) {
+    void insertMail(int mailNo, int senderMem, String mailTitle, String mailContent, char sendCancelStatus, char sendDelStatus,
+                    int receiverNo, int receiverMem, Timestamp readTime, char receiverDelStatus) {
         // given
         MailDTO newMail = new MailDTO(
-                mailNo, sender, mailTitle, mailContent, sendCancelStatus, sendDelStatus
+                mailNo, senderMem, mailTitle, mailContent, sendCancelStatus, sendDelStatus
         );
 
-        // when
-
-        // then
-        Assertions.assertDoesNotThrow(
-                () -> mailService.insertMail(newMail)
-        );
-
-        // -----------------------------------------------------------------------------------------
-        // 파일 - 임시 경로를 만들어줘서 메소드를 불러온다...??
-        // 메일, 수신자 서비스 메소드를 2개를 여기에 불러온다..???
-
-        // given
-        // 메일
-        /*MailDTO mailInfo = new MailDTO(
-                mailNo, sender, mailTitle, mailContent, sendCancelStatus, sendDelStatus
-        );
-
-        List<ReceiverDTO> receiverList = new ArrayList<>();
         ReceiverDTO receiverInfo = new ReceiverDTO(
-                receiverNo, mailNo, receiverName, readTime, receiverDelStatus
+                receiverNo,
+                mailNo,
+                receiverMem,
+                readTime,
+                receiverDelStatus
         );
-        receiverList.add(receiverInfo);
+
+//        List<ReceiverDTO>receiverList = new ArrayList<>();
+//        receiverList.add(receiverInfo);
+
+
 
         // when
 
         // then
-        Assertions.assertDoesNotThrow(
-                () -> mailService.insertMail(mailInfo)
-        );*/
+        Assertions.assertDoesNotThrow(() -> mailService.insertMail(newMail, receiverInfo));
+        System.out.println("메일 정보" + newMail);
+        System.out.println("수신자 정보" + receiverInfo);
     }
 
-    @DisplayName("메일 목록 조회")
-    @ParameterizedTest
-    @MethodSource("getMail")
-    void selectMailList() {
+    @DisplayName("보낸 메일 목록 조회")
+    @Test
+    void selectSendMailList() {
         // given
+        int senderTest = 240425003;
 
         // when
-        List<Mail> mailList = mailService.selectMailList("240423-001");
+        List<MailDTO> mailList = mailService.selectSendMailList(senderTest);
 
         // then
         Assertions.assertNotNull(mailList);
-        for(Mail mail : mailList) {
-            System.out.println("240424-001 메일 목록 : " + mail);
+        for(MailDTO mail : mailList) {
+            System.out.println(senderTest + "보낸 메일 목록 : " + mail);
+        }
+    }
+
+    @DisplayName("받은 메일 목록 조회")
+    @Test
+    void selectReceiveMailList() {
+        // given
+        int receiverTest = 240425002;
+
+        // when
+        List<MailDTO> mailList = mailService.selectReceiveMailList(receiverTest);
+
+        // then
+        Assertions.assertNotNull(mailList);
+        for(MailDTO mail : mailList) {
+            System.out.println(receiverTest +  "받은 메일 목록 : " + mail);
         }
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
0425-6시-pde -> main

### 변경 사항
메일 등록 테스트에서 수신자도 등록 가능하게 수정하였고, 발신자 메일 목록 조회, 수신자 메일 목록 조회 테스트 코드를 추가하였습니다.

### 테스트 결과
메일 테스트 코드 실행 시 메일 DB와 수신자 DB에 데이터가 저장됩니다.
발신 메일 테스트 코드 실행 시 보낸 메일의 목록이 조회되며, 수신 메일 테스트 코드 실행 시 받은 메일의 목록이 조회됩니다.

### 관련 이슈
#31 #32 
