### PR TITLE
부서별 일정 수정 컨트롤, 서비스 부분 수정

### DIFF
--- a/http/memberRestAPI.http
+++ b/http/memberRestAPI.http
@@ -321,8 +321,8 @@ Accept: */*
 
 {
 
-  "memberNo": "5",
-  "memberPW": "5555"
+  "memberNo": "3",
+  "memberPW": "3333"
 
 }
 

--- a/http/scheduleRestAPI.http
+++ b/http/scheduleRestAPI.http
@@ -3,7 +3,7 @@ GET http://localhost:8080/schedules/department/5
 Authorization: Bearer eyJkYXRlIjoxNzE1MzEzMTY2MTM0LCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLtjIDsnqUiLCJkZXBObyI6NSwibWVtYmVyTm8iOiI1IiwicG9zaXRpb25MZXZlbCI6Miwic3ViIjoia2V0Y2h1cCB0b2tlbiA6IDUiLCJyb2xlIjoiTFYyIiwicG9zaXRpb25TdGF0dXMiOiJZIiwibWVtYmVyTmFtZSI6Iuq5gO2YhOyngCIsInBvc2l0aW9uTm8iOjIsImV4cCI6MTcxNTM5OTU2NiwiZGVwTmFtZSI6IuuyleustO2MgCJ9.CHW7Wcan5z8QwyMGDsaPbUr0vsKHv0SST5Qu1rL2GhQ
 
 ### 부서별 일정 상세 조회
-GET http://localhost:8080/schedules/department/5/schedules/102
+GET http://localhost:8080/schedules/department/5/schedules/52
 Authorization: Bearer eyJkYXRlIjoxNzE1MzEzMTY2MTM0LCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLtjIDsnqUiLCJkZXBObyI6NSwibWVtYmVyTm8iOiI1IiwicG9zaXRpb25MZXZlbCI6Miwic3ViIjoia2V0Y2h1cCB0b2tlbiA6IDUiLCJyb2xlIjoiTFYyIiwicG9zaXRpb25TdGF0dXMiOiJZIiwibWVtYmVyTmFtZSI6Iuq5gO2YhOyngCIsInBvc2l0aW9uTm8iOjIsImV4cCI6MTcxNTM5OTU2NiwiZGVwTmFtZSI6IuuyleustO2MgCJ9.CHW7Wcan5z8QwyMGDsaPbUr0vsKHv0SST5Qu1rL2GhQ
 
 ### 부서별 일정 등록
@@ -22,15 +22,15 @@ Authorization: Bearer eyJkYXRlIjoxNzE1MzEzMTY2MTM0LCJ0eXBlIjoiand0IiwiYWxnIjoiSF
 }
 
 ### 부서별 일정 수정
-PUT http://localhost:8080/schedules/schedules/50
+PUT http://localhost:8080/schedules/schedules/222
 Content-Type: application/json
-Authorization: Bearer eyJkYXRlIjoxNzE1MzEzMTY2MTM0LCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLtjIDsnqUiLCJkZXBObyI6NSwibWVtYmVyTm8iOiI1IiwicG9zaXRpb25MZXZlbCI6Miwic3ViIjoia2V0Y2h1cCB0b2tlbiA6IDUiLCJyb2xlIjoiTFYyIiwicG9zaXRpb25TdGF0dXMiOiJZIiwibWVtYmVyTmFtZSI6Iuq5gO2YhOyngCIsInBvc2l0aW9uTm8iOjIsImV4cCI6MTcxNTM5OTU2NiwiZGVwTmFtZSI6IuuyleustO2MgCJ9.CHW7Wcan5z8QwyMGDsaPbUr0vsKHv0SST5Qu1rL2GhQ
+Authorization: Bearer eyJkYXRlIjoxNzE1NTAyODMwNjA0LCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLrjIDtkZwiLCJkZXBObyI6MywiaW1nVXJsIjoiNTdiMzMzYzRhZTg5NGM2ZGFhODIxODkwZWQ4OTdkNDkucG5nIiwibWVtYmVyTm8iOiIzIiwicG9zaXRpb25MZXZlbCI6Mywic3ViIjoia2V0Y2h1cCB0b2tlbiA6IDMiLCJyb2xlIjoiTFYzIiwicG9zaXRpb25TdGF0dXMiOiJZIiwibWVtYmVyTmFtZSI6IuydtOynhOyasCIsInBvc2l0aW9uTm8iOjMsImV4cCI6MTcxNTU4OTIzMCwiZGVwTmFtZSI6Iuq4sO2aje2MgCJ9.pOjTNJCig-_ObLcOYf4bBb-4RK6nlCtcAnNwoYTt7L4
 
 {
-  "skdName": "김동환 수정본",
-  "skdStartDttm": "2024-12-25 오전 10시 0분",
-  "skdEndDttm": "2024-12-25 오후 7시 0분",
-  "skdLocation": "효자로 15길 다모여빌딩",
+  "skdName": "설마 skdName을 안넣어서 수정이 안되는거라고?",
+  "skdStartDttm": "2024-05-13 오전 10시 0분",
+  "skdEndDttm": "2024-05-13 오후 7시 0분",
+  "skdLocation": "수정됨 백엔드에서 ㅅㄱ",
   "skdMemo": "수정한 일정이 정상적으로 반영되었습니다."
 }
 

--- a/src/main/java/com/devsplan/ketchup/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/devsplan/ketchup/schedule/controller/ScheduleController.java
@@ -72,7 +72,7 @@ public class ScheduleController {
     @PutMapping("/schedules/{skdNo}")
     public ResponseEntity<?> updateSchedule(@PathVariable int skdNo, @RequestBody ScheduleDTO updateSchedule) {
         try {
-            scheduleService.updateSchedule(updateSchedule);
+            scheduleService.updateSchedule(skdNo, updateSchedule);
             String uri = "/schedules/" + skdNo;
             return ResponseEntity.ok().header(HttpHeaders.LOCATION, uri).body("일정이 성공적으로 수정되었습니다. URI: " + uri);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/devsplan/ketchup/schedule/service/ScheduleService.java
+++ b/src/main/java/com/devsplan/ketchup/schedule/service/ScheduleService.java
@@ -117,8 +117,8 @@ public class ScheduleService {
     }
 
     @Transactional
-    public void updateSchedule(ScheduleDTO updateSchedule) {
-        Schedule foundSchedule = scheduleRepository.findById((long) updateSchedule.getSkdNo()).orElseThrow(IllegalArgumentException::new);
+    public void updateSchedule(int skdNo, ScheduleDTO updateSchedule) {
+        Schedule foundSchedule = scheduleRepository.findById((long) skdNo).orElseThrow(IllegalArgumentException::new);
 
         // 새로운 Schedule 객체를 생성하여 수정된 값만 적용
         Schedule updatedSchedule = new Schedule.Builder()

--- a/src/test/java/com/devsplan/ketchup/schedule/ScheduleServiceTests.java
+++ b/src/test/java/com/devsplan/ketchup/schedule/ScheduleServiceTests.java
@@ -46,8 +46,8 @@ public class ScheduleServiceTests {
     @Test
     void selectScheduleDetail() {
         // given
-        int dptNo = 5;
-        int skdNo = 12;
+        int dptNo = 3;
+        int skdNo = 222;
 
         // when
         ScheduleDTO foundSchedule = scheduleService.selectScheduleDetail(dptNo, skdNo);
@@ -97,18 +97,17 @@ public class ScheduleServiceTests {
     void updateSchedule(int skdNo, int dptNo, String skdName, String skdStartDttm, String skdEndDttm, String skdLocation, String skdMemo) {
         // given
         ScheduleDTO updateSchedule = new ScheduleDTO(
-                12,
+                222,
                 new DepartmentDTO(dptNo),
-                "수정된 일정!!!!!!!!!!!!!!!!!!",
-                "2024-05-10 8:00",
-//                LocalDateTime.of(2025, 6, 23, 10, 0),
-                skdEndDttm,
-                "수정된 위치!!!!!!!!!!!",
-                "수정된 메모!!!!!!!!!!!!!"
+                "다시 수정됨?",
+                "2024-05-13 8:00",
+                "2024-05-13 9:00",
+                "서비스 테스트에서 수정",
+                "서비스 테스트에서 수정"
         );
 
         // then
-        Assertions.assertDoesNotThrow(() -> scheduleService.updateSchedule(updateSchedule));
+        Assertions.assertDoesNotThrow(() -> scheduleService.updateSchedule(updateSchedule.getSkdNo(), updateSchedule));
     }
 
     @DisplayName("부서별 일정 삭제")


### PR DESCRIPTION
[Feature-0512]( ) - ScheduleService, ScheduleController - 부서별 일정 수정 컨트롤러, 서비스 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Jay-20240512-v1

### 변경 사항
##서비스
변경 부분: 변경될 내용에서 skdNo를 추출하라는 로직으로 작성한 부분을 직접적으로 전달할 수 있도록 변경함. 변경내용에 skdNo를 별도로 추가할 필요가 없기때문에, 목록 조회에서 상세조회로 넘어갈때 사용하는 일정 번호(skdNo)를 사용할 수 있도록 함.
<변경 전>
```java
        Schedule foundSchedule = scheduleRepository.findById((long) updateSchedule.getSkdNo()).orElseThrow(IllegalArgumentException::new);
``` 
<변경 후>
```java
        Schedule foundSchedule = scheduleRepository.findById((long) skdNo).orElseThrow(IllegalArgumentException::new);
``` 

##컨트롤러
변경 부분: 컨트롤러에서 서비스로 넘어갈때 매개변수로 skdNo와 변경될 내용을 전달해줌.
<변경 전> - **해당 부분에서 예약 번호를 전달해주지 않아서 클라이언트에서 서버로 보내는 요청의 URI가 잘못되었다는 오류가 있었음. **
```java
            scheduleService.updateSchedule(updateSchedule);
``` 
<변경 후>
```java
            scheduleService.updateSchedule(skdNo, updateSchedule);
``` 

### 테스트 결과
성공적으로 일정을 수정할 수 있게되었습니다.
자원 예약의 경우 컨트롤러와 서비스단 모두 테스트 코드를 작성하여 정상 작동하는지 확인하였으나, 일정의 경우 오직 서비스단만 테스트코드를 사용하며 작성하다보니, 컨트롤러에서 이런 오류가 있었습니다.
테스트 코드의 중요성...

#이슈번호
